### PR TITLE
Cleanups and some improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,24 +8,18 @@ This shell script is designed to list the dependencies of two different versions
 
 ## How does it work
 - Fetches the older Jenkins war file with `mvn dependency:get -DartifactId=jenkins-war -DgroupId=org.jenkins-ci.main -Dpackaging=war -Dversion=$VERSION_ONE -Dtransitive=false`
-- Unzips it to a folder `unzip -q ~/.m2/repository/org/jenkins-ci/main/jenkins-war/$VERSION_ONE/jenkins-war-$VERSION_ONE.war -d $VERSION_ONE`
+- Uses `jar` CLI to list the content of the war
 - Fetches the newer Jenkins war file with `mvn dependency:get -DartifactId=jenkins-war -DgroupId=org.jenkins-ci.main -Dpackaging=war -Dversion=$VERSION_TWO -Dtransitive=false`
-- Unzips the newer one `unzip -q ~/.m2/repository/org/jenkins-ci/main/jenkins-war/$VERSION_TWO/jenkins-war-$VERSION_TWO.war -d $VERSION_TWO`
+- List the content of the newest war with `jar` CLI
 - list out and compare the diff between `/WEB-INF/lib/*`
 
 ## Usage 
 - clone the code
 - cd to the folder
-- make sure the `maven` and `unzip` are installed
+- make sure the `maven`, `jar`, and `diff2html-cli` are installed
 - run these
   ```bash
-  chmod +x jenkins-list-dependency-changes.sh
-  ./jenkins-list-dependency-changes.sh
-  ```
-- Follow the prompts to enter the Jenkins versions you want to compare:
-  ```bash
-  Enter the old version: <older_version>
-  Enter the new version: <newer_version>
+  VERSION_ONE=<old_version> VERSION_TWO=<new_version> bash jenkins-list-dependency-changes.sh
   ```
 ## Sample Output
 ![jenkins-diff](https://github.com/user-attachments/assets/de307b6d-a22c-400a-9afb-68946e335454)
@@ -34,17 +28,8 @@ This shell script is designed to list the dependencies of two different versions
 ## To view the diff (optional Step)
 the script also creates a html diff using diff2html. To use diff2html, you need Node.js installed on your system. If diff2html is not installed, the script will just throw a warning. You will need to do the diff on your own
 
-how to do this on mac
+how to do this:
 ```bash
-brew install node
-npm install diff2html
-npm install diff2html-cli
-```
-
-how to do this on ubuntu
-```bash
-apt install -y nodejs
-apt install -y npm
-npm install diff2html
-npm install diff2html-cli
+asdf install node stable
+npm install -g diff2html-cli
 ```

--- a/jenkins-list-dependency-changes.sh
+++ b/jenkins-list-dependency-changes.sh
@@ -2,11 +2,11 @@
 set -euo pipefail
 
 # Prompt the user to enter versions
-if [[ -z  "${VERSION_ONE-''}" ]]; then
-    read -p "Enter the old version: " VERSION_ONE
+if [[ -z  "${OLD-''}" ]]; then
+    read -p "Enter the old version: " OLD
 fi
-if [[ -z "${VERSION_TWO-''}" ]]; then
-    read -p "Enter the new version: " VERSION_TWO
+if [[ -z "${NEW-''}" ]]; then
+    read -p "Enter the new version: " NEW
 fi
 
 # Colors for output
@@ -29,30 +29,30 @@ get_dependencie_list() {
 }
 
 # Download the older Jenkins war
-get_war ${VERSION_ONE}
+get_war ${OLD}
 
-# Unzip its contents to VERSION_ONE folder
-get_dependencie_list ${VERSION_ONE}
+# Unzip its contents to OLD folder
+get_dependencie_list ${OLD}
 
 # Download the newer Jenkins war
-get_war ${VERSION_TWO}
+get_war ${NEW}
 
-# Unzip its contents to VERSION_TWO folder
-get_dependencie_list ${VERSION_TWO}
+# Unzip its contents to NEW folder
+get_dependencie_list ${NEW}
 
-diff --unified=0 ${VERSION_ONE}_libs.txt ${VERSION_TWO}_libs.txt > lib_diff.txt || true
+diff --unified=0 ${OLD}_libs.txt ${NEW}_libs.txt > lib_diff.txt || true
 
 # Create compare URLs for Jenkins core
-JENKINSCORE_COMPARE_URL="https://github.com/cloudbees/private-jenkins/compare/jenkins-$VERSION_ONE...jenkins-$VERSION_TWO"
+JENKINSCORE_COMPARE_URL="https://github.com/cloudbees/private-jenkins/compare/jenkins-$OLD...jenkins-$NEW"
 echo -e "\n${CYAN}Jenkins core compare URL:${YELLOW} $JENKINSCORE_COMPARE_URL${NC}"
 echo -e "${CYAN}Refernce for comparison URL for artifacts: ${YELLOW}https://docs.google.com/spreadsheets/d/1GY3yMmW8HsGzTTPIt_lSzZOQQ1UM0JFCswddY3oeuig/edit?usp=sharing${NC}"
 
 # Generate diff and convert to HTML for dependency (optional: for diff2html to work you will need to install Node.js)
-diff2html --title "Jenkins core jar compare $VERSION_ONE VS $VERSION_TWO" \
+diff2html --title "Jenkins core jar compare $OLD VS $NEW" \
     --input file \
     --output stdout \
     --fileContentToggle false \
     -- lib_diff.txt > lib_diff.html
 
 # Cleanup
-rm ${VERSION_ONE}_libs.txt ${VERSION_TWO}_libs.txt
+rm ${OLD}_libs.txt ${NEW}_libs.txt

--- a/jenkins-list-dependency-changes.sh
+++ b/jenkins-list-dependency-changes.sh
@@ -55,4 +55,4 @@ diff2html --title "Jenkins core jar compare $VERSION_ONE VS $VERSION_TWO" \
     -- lib_diff.txt > lib_diff.html
 
 # Cleanup
-rm $VERSION_ONE_libs.txt $VERSION_TWO_libs.txt
+rm ${VERSION_ONE}_libs.txt ${VERSION_TWO}_libs.txt

--- a/jenkins-list-dependency-changes.sh
+++ b/jenkins-list-dependency-changes.sh
@@ -14,17 +14,22 @@ CYAN='\033[0;36m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
+get_war() {
+    local version="${1}"
+
+    echo -e "${CYAN}Running : ${YELLOW}mvn dependency:get -DartifactId=jenkins-war -DgroupId=org.jenkins-ci.main -Dpackaging=war -Dversion="${version}" -Dtransitive=false${NC}"
+    mvn -q dependency:get -DartifactId=jenkins-war -DgroupId=org.jenkins-ci.main -Dpackaging=war -Dversion="${version}" -Dtransitive=false
+}
+
 # Download the older Jenkins war
-echo -e "${CYAN}Running : ${YELLOW}mvn dependency:get -DartifactId=jenkins-war -DgroupId=org.jenkins-ci.main -Dpackaging=war -Dversion=$VERSION_ONE -Dtransitive=false${NC}"
-mvn dependency:get -DartifactId=jenkins-war -DgroupId=org.jenkins-ci.main -Dpackaging=war -Dversion=$VERSION_ONE -Dtransitive=false
+get_war ${VERSION_ONE}
 
 # Unzip its contents to VERSION_ONE folder
 echo -e "${CYAN}Running : ${YELLOW}unzip -q ~/.m2/repository/org/jenkins-ci/main/jenkins-war/$VERSION_ONE/jenkins-war-$VERSION_ONE.war -d $VERSION_ONE${NC}\n\n"
 unzip -q ~/.m2/repository/org/jenkins-ci/main/jenkins-war/$VERSION_ONE/jenkins-war-$VERSION_ONE.war -d $VERSION_ONE
 
 # Download the newer Jenkins war
-echo -e "${CYAN}Running : ${YELLOW}mvn dependency:get -DartifactId=jenkins-war -DgroupId=org.jenkins-ci.main -Dpackaging=war -Dversion=$VERSION_TWO -Dtransitive=false${NC}"
-mvn dependency:get -DartifactId=jenkins-war -DgroupId=org.jenkins-ci.main -Dpackaging=war -Dversion=$VERSION_TWO -Dtransitive=false
+get_war ${VERSION_TWO}
 
 # Unzip its contents to VERSION_TWO folder
 echo -e "${CYAN}Running : ${YELLOW}unzip -q ~/.m2/repository/org/jenkins-ci/main/jenkins-war/$VERSION_TWO/jenkins-war-$VERSION_TWO.war -d $VERSION_TWO${NC}"

--- a/jenkins-list-dependency-changes.sh
+++ b/jenkins-list-dependency-changes.sh
@@ -44,17 +44,6 @@ get_dependencie_list ${VERSION_TWO}
 
 diff -u ${VERSION_ONE}_libs.txt ${VERSION_TWO}_libs.txt > lib_diff.txt
 
-# Output the differences
-printf "\n\n\n"
-
-echo -e "${CYAN}$VERSION_ONE ${YELLOW}dependency:${NC}"
-cat ${VERSION_ONE}_libs.txt
-
-printf "\n\n"
-
-echo -e "${CYAN}$VERSION_TWO ${YELLOW}dependency:${NC}"
-cat ${VERSION_TWO}_libs.txt
-
 # Create compare URLs for Jenkins core
 JENKINSCORE_COMPARE_URL="https://github.com/cloudbees/private-jenkins/compare/jenkins-$VERSION_ONE...jenkins-$VERSION_TWO"
 echo -e "\n\n${CYAN}Jenkins core compare URL:${YELLOW} $JENKINSCORE_COMPARE_URL${NC}"

--- a/jenkins-list-dependency-changes.sh
+++ b/jenkins-list-dependency-changes.sh
@@ -40,18 +40,19 @@ get_war ${VERSION_TWO}
 # Unzip its contents to VERSION_TWO folder
 get_dependencie_list ${VERSION_TWO}
 
-diff -u ${VERSION_ONE}_libs.txt ${VERSION_TWO}_libs.txt > lib_diff.txt
+diff --unified=0 ${VERSION_ONE}_libs.txt ${VERSION_TWO}_libs.txt > lib_diff.txt || true
 
 # Create compare URLs for Jenkins core
 JENKINSCORE_COMPARE_URL="https://github.com/cloudbees/private-jenkins/compare/jenkins-$VERSION_ONE...jenkins-$VERSION_TWO"
-echo -e "\n\n${CYAN}Jenkins core compare URL:${YELLOW} $JENKINSCORE_COMPARE_URL${NC}"
-
+echo -e "\n${CYAN}Jenkins core compare URL:${YELLOW} $JENKINSCORE_COMPARE_URL${NC}"
 echo -e "${CYAN}Refernce for comparison URL for artifacts: ${YELLOW}https://docs.google.com/spreadsheets/d/1GY3yMmW8HsGzTTPIt_lSzZOQQ1UM0JFCswddY3oeuig/edit?usp=sharing${NC}"
 
-
 # Generate diff and convert to HTML for dependency (optional: for diff2html to work you will need to install Node.js)
-diff -u ${VERSION_ONE}_libs.txt ${VERSION_TWO}_libs.txt > diff_libs.txt
-diff2html -t "Jenkins core jar compare $VERSION_ONE VS $VERSION_TWO" -i file -- diff_libs.txt > diff_libs.html 
+diff2html --title "Jenkins core jar compare $VERSION_ONE VS $VERSION_TWO" \
+    --input file \
+    --output stdout \
+    --fileContentToggle false \
+    -- lib_diff.txt > lib_diff.html
 
 # Cleanup
 rm *diff* *version*

--- a/jenkins-list-dependency-changes.sh
+++ b/jenkins-list-dependency-changes.sh
@@ -55,5 +55,4 @@ diff2html --title "Jenkins core jar compare $VERSION_ONE VS $VERSION_TWO" \
     -- lib_diff.txt > lib_diff.html
 
 # Cleanup
-rm *diff* *version*
-rm -rf $VERSION_ONE $VERSION_TWO
+rm $VERSION_ONE_libs.txt $VERSION_TWO_libs.txt

--- a/jenkins-list-dependency-changes.sh
+++ b/jenkins-list-dependency-changes.sh
@@ -24,7 +24,7 @@ get_war() {
 get_dependencie_list() {
     local version="${1}"
 
-    echo -e "${CYAN}Running : ${YELLOW}unzip -q ~/.m2/repository/org/jenkins-ci/main/jenkins-war/${version}/jenkins-war-${version}.war -d ${version}${NC}\n\n"
+    echo -e "${CYAN}Running : ${YELLOW}unzip -q ~/.m2/repository/org/jenkins-ci/main/jenkins-war/${version}/jenkins-war-${version}.war -d ${version}${NC}"
     unzip -q ~/.m2/repository/org/jenkins-ci/main/jenkins-war/${version}/jenkins-war-${version}.war -d ${version}
 
     ls -1 ${version}/WEB-INF/lib/ > ${version}_libs.txt

--- a/jenkins-list-dependency-changes.sh
+++ b/jenkins-list-dependency-changes.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
+set -euo pipefail
 
 # Prompt the user to enter versions
 read -p "Enter the old version: " VERSION_ONE

--- a/jenkins-list-dependency-changes.sh
+++ b/jenkins-list-dependency-changes.sh
@@ -2,8 +2,12 @@
 set -euo pipefail
 
 # Prompt the user to enter versions
-read -p "Enter the old version: " VERSION_ONE
-read -p "Enter the new version: " VERSION_TWO
+if [[ -z  "${VERSION_ONE-''}" ]]; then
+  read -p "Enter the old version: " VERSION_ONE
+fi
+if [[ -z "${VERSION_TWO-''}" ]]; then
+  read -p "Enter the new version: " VERSION_TWO
+fi
 
 # Colors for output
 CYAN='\033[0;36m'

--- a/jenkins-list-dependency-changes.sh
+++ b/jenkins-list-dependency-changes.sh
@@ -24,10 +24,8 @@ get_war() {
 get_dependencie_list() {
     local version="${1}"
 
-    echo -e "${CYAN}Running : ${YELLOW}unzip -q ~/.m2/repository/org/jenkins-ci/main/jenkins-war/${version}/jenkins-war-${version}.war -d ${version}${NC}"
-    unzip -q ~/.m2/repository/org/jenkins-ci/main/jenkins-war/${version}/jenkins-war-${version}.war -d ${version}
-
-    ls -1 ${version}/WEB-INF/lib/ > ${version}_libs.txt
+    echo -e "${CYAN}Running : ${YELLOW}jar --list --file [jenkins-war-${version}.war]${NC}"
+    jar --list --file ${HOME}/.m2/repository/org/jenkins-ci/main/jenkins-war/${version}/jenkins-war-${version}.war | grep --extended-regexp "WEB-INF/lib/.*\.jar" | sort > ${version}_libs.txt
 }
 
 # Download the older Jenkins war

--- a/jenkins-list-dependency-changes.sh
+++ b/jenkins-list-dependency-changes.sh
@@ -3,10 +3,10 @@ set -euo pipefail
 
 # Prompt the user to enter versions
 if [[ -z  "${VERSION_ONE-''}" ]]; then
-  read -p "Enter the old version: " VERSION_ONE
+    read -p "Enter the old version: " VERSION_ONE
 fi
 if [[ -z "${VERSION_TWO-''}" ]]; then
-  read -p "Enter the new version: " VERSION_TWO
+    read -p "Enter the new version: " VERSION_TWO
 fi
 
 # Colors for output


### PR DESCRIPTION
This is generally improves script readability and let use the script with environment variables so there is no user interrupt.

You can use:
```
VERSION_ONE=a VERSION_TWO=b bash jenkins-list-dependency-changes
```